### PR TITLE
fix: don't capitalize tags

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -3,6 +3,8 @@ title: Andrey Nautilus blog
 paginate: 5
 theme: PaperMod
 
+titleCaseStyle: none  # do not capitalize titles
+
 # Configure for publishing on GitHub Pages
 cleanDestinationDir: true
 publishDir: docs


### PR DESCRIPTION
Don't "Capitalize" tags in posts.
https://discourse.gohugo.io/t/how-can-i-force-tags-to-be-all-lowercase/48420