### PR TITLE
refactor: use page bundles instead of shortcodes

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -3,10 +3,11 @@
         {
             "pattern": "\\.\\./links",
             "replacement": "links.md"
-        },
+        }
+    ],
+    "ignorePatterns": [
         {
-            "pattern": "\\.\\./(?<post_link>posts/.*)",
-            "replacement": "$<post_link>.md"
+            "pattern": ".*/posts/.*"
         }
     ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,11 @@ repos:
         additional_dependencies:
           - mdformat-gfm
           - mdformat-frontmatter
-        exclude: |
-            (?x)^(
-                content/posts/2024-07-21-evenly-random-points-on-plane.md|
-                content/posts/2024-07-29-random-points-in-circle.md
-            )$
+        # exclude: |
+        #     (?x)^(
+        #         content/posts/2024-07-21-evenly-random-points-on-plane.md|
+        #         content/posts/2024-07-29-random-points-in-circle.md
+        #     )$
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -41,10 +41,10 @@ repos:
         name: Common misspellings
 
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.13.6
+    rev: v3.13.7
     hooks:
       - id: markdown-link-check
-        args: ['--config', '.markdown-link-check.json']
+        args: ['--config', '.markdown-link-check.json', '-v']
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,11 +28,6 @@ repos:
         additional_dependencies:
           - mdformat-gfm
           - mdformat-frontmatter
-        # exclude: |
-        #     (?x)^(
-        #         content/posts/2024-07-21-evenly-random-points-on-plane.md|
-        #         content/posts/2024-07-29-random-points-in-circle.md
-        #     )$
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/content/posts/2024-07-21-evenly-random-points-on-plane/index.md
+++ b/content/posts/2024-07-21-evenly-random-points-on-plane/index.md
@@ -21,7 +21,7 @@ The simplest approach - to use uniformly distributed points with `(random(), ran
 because there will be areas with high density of points and areas with no points at all.
 Such distribution doesn't look _natural_.
 
-{{< random_points_uniform_distribution numPoints=1700 >}}
+{{< load_resource "uniform_distribution.html" >}}
 
 Various types of grids with gaps can give even distribution, but the picture will not look _random_.
 There will always be a pattern, sometimes more visible, sometimes less, but still visible. This
@@ -30,7 +30,7 @@ doesn't look _natural_ either.
 A solution to this problem is [Poisson disk sampling (or Poisson disk distribution)](https://en.wikipedia.org/wiki/Supersampling#Poisson_disk):
 points are placed randomly, but not too close and not too far away from each other.
 
-{{< random_points_poisson_disk_distribution radius=10 >}}
+{{< load_resource "poisson_disk_distribution.html" >}}
 
 [This article](https://bost.ocks.org/mike/algorithms/) compares randomly placed points with
 Poisson disk distribution, and shows "best candidate" and [Bridson’s](https://www.cs.ubc.ca/~rbridson/docs/bridson-siggraph07-poissondisk.pdf)

--- a/content/posts/2024-07-21-evenly-random-points-on-plane/poisson_disk_distribution.html
+++ b/content/posts/2024-07-21-evenly-random-points-on-plane/poisson_disk_distribution.html
@@ -1,34 +1,27 @@
-{{ $seed := "random_points_uniform_distribution" }}
-{{ $svgName := add "a" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $captionName := add "c" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $width := 700 }}
-{{ $height := 400 }}
 <p>
   <svg
-    id="{{ $svgName }}"
+    id="poisson_disk_dist"
     width="100%"
     height="100%"
-    viewBox="0 0 {{ $width }} {{ $height }}"
+    viewBox="0 0 700 400"
     >
     <!-- points -->
   </svg>
   <p
-    id="{{ $captionName }}"
+    id="poisson_disk_dist_caption"
     style="text-align: center;">
     Caption
   </p>
 </p>
 <script type="module">
-
-const svgns = 'http://www.w3.org/2000/svg';
-
-const width = {{ $width }};
-const height = {{ $height }};
-
-const radius = {{ if (.Get "radius") }}{{ .Get "radius" }}{{ else }}10{{end}};
-
 function renderSVG_PoissonDiskDistribution() {
-  let svg = document.getElementById('{{ $svgName }}');
+  const svgns = 'http://www.w3.org/2000/svg';
+
+  let svg = document.getElementById('poisson_disk_dist');
+  const width = 700;
+  const height = 400;
+
+  const radius = 10;
 
   // clear existing points
   while (svg.firstChild) {
@@ -36,7 +29,7 @@ function renderSVG_PoissonDiskDistribution() {
   }
 
   const points = generatePointsByPoissonDiskDistribution(width, height, radius);
-  document.getElementById('{{ $captionName }}').innerText = `${points.length} points`;
+  document.getElementById('poisson_disk_dist_caption').innerText = `${points.length} points`;
 
   for (let p of points) {
     let circle = document.createElementNS(svgns, 'circle');
@@ -160,7 +153,7 @@ function generatePointsByPoissonDiskDistribution(width, height, radius) {
   }
 }
 
-document.getElementById('{{ $svgName }}').addEventListener('click', renderSVG_PoissonDiskDistribution);
+document.getElementById('poisson_disk_dist').addEventListener('click', renderSVG_PoissonDiskDistribution);
 
 renderSVG_PoissonDiskDistribution()
 

--- a/content/posts/2024-07-21-evenly-random-points-on-plane/uniform_distribution.html
+++ b/content/posts/2024-07-21-evenly-random-points-on-plane/uniform_distribution.html
@@ -1,35 +1,29 @@
-{{ $seed := "random_points_uniform_distribution" }}
-{{ $svgName := add "a" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $captionName := add "c" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $width := 700 }}
-{{ $height := 400 }}
 <p>
   <svg
-    id="{{ $svgName }}"
+    id="uniform_distribution"
     width="100%"
     height="100%"
-    viewBox="0 0 {{ $width }} {{ $height }}"
+    viewBox="0 0 700 400"
     >
     <!-- points -->
   </svg>
   <p
-    id="{{ $captionName }}"
+    id="uniform_distribution_caption"
     style="text-align: center;">
     Caption
   </p>
 </p>
 <script type="module">
 
-const svgns = 'http://www.w3.org/2000/svg';
-
-const width = {{ $width }};
-const height = {{ $height }};
-
-const numPoints = {{ if (.Get "numPoints") }}{{ .Get "numPoints" }}{{ else }}1000{{end}};
-document.getElementById('{{ $captionName }}').innerText = `${numPoints} points`;
+const numPoints = 1700;
+document.getElementById('uniform_distribution_caption').innerText = `${numPoints} points`;
 
 function renderSVG_UniformDistribution() {
-  let svg = document.getElementById('{{ $svgName }}');
+  const svgns = 'http://www.w3.org/2000/svg';
+  let svg = document.getElementById('uniform_distribution');
+
+  const width = 700;
+  const height = 400;
 
   // clear existing points
   while (svg.firstChild) {
@@ -56,7 +50,7 @@ function generatePointsByUniformDistribution(width, height, amount) {
   return result;
 }
 
-document.getElementById('{{ $svgName }}').addEventListener('click', renderSVG_UniformDistribution);
+document.getElementById('uniform_distribution').addEventListener('click', renderSVG_UniformDistribution);
 
 renderSVG_UniformDistribution();
 

--- a/content/posts/2024-07-29-random-points-in-circle/index.md
+++ b/content/posts/2024-07-29-random-points-in-circle/index.md
@@ -16,7 +16,7 @@ doesn't give uniform distribution - there are more points close to center and fe
 [This article](https://www.anderswallin.net/2009/05/uniform-random-points-in-a-circle-using-polar-coordinates/)
 has explanation and visualization.
 
-{{< random_points_in_circle >}}
+{{< load_resource "random_points_in_circle.html" >}}
 
 ## Correct formula for polar coordinates
 

--- a/content/posts/2024-07-29-random-points-in-circle/random_points_in_circle.html
+++ b/content/posts/2024-07-29-random-points-in-circle/random_points_in_circle.html
@@ -1,30 +1,25 @@
-{{ $seed := "random_points_in_circle" }}
-{{ $svgName := add "a" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $captionName := add "c" (delimit (shuffle (split (md5 $seed) "" )) "") }}
-{{ $width := 620 }}
-{{ $height := 200 }}
 <p>
   <svg
-    id="{{ $svgName }}"
+    id="random_points_in_circles"
     width="100%"
     height="100%"
-    viewBox="0 0 {{ $width }} {{ $height }}"
+    viewBox="0 0 620 200"
     >
     <!-- points -->
   </svg>
   <p
-    id="{{ $captionName }}"
+    id="random_points_in_circles_caption"
     style="text-align: center;">
     NNN points, left to right: naive approach, correct formula, Monte Carlo (XXX attempts)
   </p>
 </p>
 <script type="module">
 
-const svgns = 'http://www.w3.org/2000/svg';
-const numPoints = 250;
-
 function renderSVG_RandomPointsInCircle() {
-  let svg = document.getElementById('{{ $svgName }}');
+  const svgns = 'http://www.w3.org/2000/svg';
+  const numPoints = 250;
+
+  let svg = document.getElementById('random_points_in_circles');
 
   // clear existing points
   while (svg.firstChild) {
@@ -61,7 +56,7 @@ function renderSVG_RandomPointsInCircle() {
     svg.appendChild(circle);
   }
 
-  let caption = document.getElementById('{{ $captionName }}');
+  let caption = document.getElementById('random_points_in_circles_caption');
   let text = `${numPoints} points, left to right: naive approach, correct formula, Monte Carlo (${attempts} attempts)`;
   caption.innerText = text;
 }
@@ -113,7 +108,7 @@ function generatePointsMonteCarlo(centerX, centerY, radius, amount) {
   return [attempts, result];
 }
 
-document.getElementById('{{ $svgName }}').addEventListener('click', renderSVG_RandomPointsInCircle);
+document.getElementById('random_points_in_circles').addEventListener('click', renderSVG_RandomPointsInCircle);
 
 renderSVG_RandomPointsInCircle()
 

--- a/layouts/shortcodes/load_resource.html
+++ b/layouts/shortcodes/load_resource.html
@@ -1,0 +1,12 @@
+{{- /*  Insert a file from page bundle as plain html block  */ -}}
+
+{{- with .Get 0 }}
+  {{- $resPattern := add "*" ($.Get 0) }}
+  {{- with $.Page.Resources.GetMatch $resPattern }}
+    {{- .Content }}
+  {{- else }}
+    {{- errorf "The %q shortcode was unable to find %s: see %s" $.Name ($.Get 0) $.Position }}
+  {{- end }}
+{{- else }}
+  {{- errorf "The %q shortcode requires an argument: see %s" $.Name $.Position }}
+{{- end }}

--- a/layouts/shortcodes/load_script.html
+++ b/layouts/shortcodes/load_script.html
@@ -1,0 +1,12 @@
+{{- /*  Load a JS script file from page bundle as <script></script> tag  */ -}}
+
+{{- with .Get 0 }}
+  {{- $resPattern := add "*" ($.Get 0) }}
+  {{- with $.Page.Resources.GetMatch $resPattern }}
+    <script src="{{ .RelPermalink }}"></script>
+  {{- else }}
+    {{- errorf "The %q shortcode was unable to find %s: see %s" $.Name ($.Get 0) $.Position }}
+  {{- end }}
+{{- else }}
+  {{- errorf "The %q shortcode requires an argument: see %s" $.Name $.Position }}
+{{- end }}


### PR DESCRIPTION
- use page bundles instead of shortcodes for existing posts;
- `markdown-link-check`: ignore links to "posts" (it's hard to validate them, because resulting urls differ from file locations);
- `post-enumerating`: check page bundles;