### PR TITLE
ci: use htmltest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,3 +53,10 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: docs
           retention-days: 1
+      - name: Install htmltest
+        run: |
+          curl https://htmltest.wjdp.uk | bash
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Validate with htmltest
+        run: |
+          htmltest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 
 .hugo_build.lock
 docs
+tmp

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,17 @@
+# htmltest config, see: https://github.com/wjdp/htmltest
+
+DirectoryPath: docs  # must match 'publishDir' in hugo.yaml
+ExternalTimeout: 30  # seconds
+# Hugo's directory structure triggers this:
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreURLs:
+  # Don't check LinkedIn, it return http 999 for GET requests
+  - https://www.linkedin.com/in/andrey-potapov-1049b096/
+  # I don't have favicons and "apple" icons at the moment :(
+  - https://andreynautilus\.github\.io/favicon(-\d+x\d+)?\.(ico|png)
+  - https://andreynautilus\.github\.io/apple-touch-icon\.png
+  - https://andreynautilus\.github\.io/safari-pinned-tab\.svg
+  # Links to gnu.org often time out, even though they work properly in browser
+  - https://www.gnu.org/.+
+IgnoreAltEmpty: true
+LogLevel: 1  # 'info' log level


### PR DESCRIPTION
`htmltest` checks links in the produced html files. It's a final check before rolling out.

### Details

- https://github.com/wjdp/htmltest - the tool
- [article](https://robb.sh/posts/check-links-in-hugo-with-htmltest/) with an example usage;

Implements: https://github.com/AndreyNautilus/AndreyNautilus.github.io/issues/93